### PR TITLE
markdownレンダリングエンジンを搭載

### DIFF
--- a/bin/koko
+++ b/bin/koko
@@ -20,6 +20,10 @@ var argv = require('optimist')
     .describe('php', 'using express-php')
     .boolean('php')
 
+    .describe('md', 'using markdown rendering')
+    .boolean('md')
+    .alias('m', 'md')
+
     .describe('h', 'show this help menu')
     .boolean('h')
     .alias('h', 'help')
@@ -38,7 +42,8 @@ var koko = new Koko(dirpath, {
     openPath: argv.o,
     staticPort: argv.port,
     proxyURL: argv.u,
-    usePHP: argv.php
+    usePHP: argv.php,
+    useMarkdown: argv.md
 });
 
 koko.start();

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "colors": "~0.6.0-1",
     "async": "~0.2.6",
     "http-proxy": "~0.10.0",
-    "php-express": "0.0.1"
+    "php-express": "0.0.1",
+    "markdown": "^0.5.0"
   },
   "description": "instant web server (proxy server).",
   "main": "index.js",


### PR DESCRIPTION
- `useMarkdown`フラグをtrueにして使うと、markdownのレンダリングがオンになる
- `.md`で終わるファイルにて有効
- `--md` オプションをつけると、binからも使える